### PR TITLE
So sat mbs v1

### DIFF
--- a/sofind/datamodels/so_sat_v1.yaml
+++ b/sofind/datamodels/so_sat_v1.yaml
@@ -1,0 +1,10 @@
+qids_config: so_basic_qids.yaml  
+
+maps: 
+  default_config: so_sat_v1_f1.yaml
+
+masks:
+  so_sat_v1_f1_masks: so_sat_v1_f1_masks.yaml
+
+noise_models:
+  default_config: so_sat_v1_f1.yaml

--- a/sofind/products/maps/README.md
+++ b/sofind/products/maps/README.md
@@ -8,6 +8,7 @@ We give additional information for each `maps` config file, such as permissible 
 | act_dr6v3.yaml| `pa4a`, `pa4a_dw`, `pa4a_dd`, `pa4b`, `pa4b_dw`, `pa4b_dd`, `pa5a`, `pa5a_dw`, `pa5a_dd`, `pa5b`, `pa5b_dw`, `pa5b_dd`, `pa6a`, `pa6a_dw`, `pa6a_dd`, `pa6b`, `pa6b_dw`, `pa6b_dd`, `pa7a`, `pa7a_dw`, `pa7b`, `pa7b_dw` |
 | act_dr6v3_pwv_split.yaml | `pa4a`, `pa4a_dw`, `pa4a_dd`, `pa4b`, `pa4b_dw`, `pa4b_dd`, `pa5a`, `pa5a_dw`, `pa5a_dd`, `pa5b`, `pa5b_dw`, `pa5b_dd`, `pa6a`, `pa6a_dw`, `pa6a_dd`, `pa6b`, `pa6b_dw`, `pa6b_dd` |
 | so_scan_s0003.yaml | `lfa`, `lfb`, `mfa`, `mfb`, `uhfa`, `uhfb` |
+| so_sat_v1_f1.yaml | `lfa`, `lfb`, `mfa`, `mfb`, `uhfa`, `uhfb` |
 
 ## Required Additional Keyword Arguments
 | Config File | Additional Keywords | Possible Values |
@@ -16,3 +17,4 @@ We give additional information for each `maps` config file, such as permissible 
 | act_dr6v3.yaml| | |
 | act_dr6v3_pwv_split.yaml | `null_split` | `low_pwv`, `high_pwv` |
 | so_scan_s0003.yaml | |
+| so_sat_v1_f1.yaml | |

--- a/sofind/products/maps/so_sat_v1_f1.yaml
+++ b/sofind/products/maps/so_sat_v1_f1.yaml
@@ -1,5 +1,5 @@
 system_paths:
-  perlmutter: /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1/car
+  perlmutter: /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/car/
   rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car
 
 allowed_qids_configs:

--- a/sofind/products/maps/so_sat_v1_f1.yaml
+++ b/sofind/products/maps/so_sat_v1_f1.yaml
@@ -1,0 +1,29 @@
+system_paths:
+  perlmutter: /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1/car
+  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car
+
+allowed_qids_configs:
+- so_basic_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+  lfa:
+    num_splits: 2
+
+  lfb:
+    num_splits: 2
+
+  mfa:
+    num_splits: 2
+
+  mfb:
+    num_splits: 2
+
+  uhfa:
+    num_splits: 2
+
+  uhfb:
+    num_splits: 2
+
+split_map_file_template: 'coadd_SAT_{freq}_{num_splits}way_set0{split_num}_{maptag}_inpaint.fits'

--- a/sofind/products/masks/so_sat_v1_f1_masks.yaml
+++ b/sofind/products/masks/so_sat_v1_f1_masks.yaml
@@ -1,0 +1,9 @@
+system_paths:
+  perlmutter: /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1/car/masks
+  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/masks
+
+allowed_qids_configs: 'all'
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:

--- a/sofind/products/masks/so_sat_v1_f1_masks.yaml
+++ b/sofind/products/masks/so_sat_v1_f1_masks.yaml
@@ -1,5 +1,5 @@
 system_paths:
-  perlmutter: /global/cfs/cdirs/sobs/sims/sat-noise-sims/v1/car/masks
+  perlmutter: /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920/car/masks
   rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/masks
 
 allowed_qids_configs: 'all'

--- a/sofind/products/noise_models/so_sat_v1_f1.yaml
+++ b/sofind/products/noise_models/so_sat_v1_f1.yaml
@@ -32,7 +32,6 @@ fdw_lf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null
@@ -102,7 +101,6 @@ fdw_mf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null
@@ -180,7 +178,6 @@ fdw_uhf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null
@@ -258,7 +255,6 @@ tile_lf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null
@@ -298,7 +294,6 @@ tile_mf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null
@@ -338,7 +333,6 @@ tile_uhf:
   subproduct: default
   maps_product: maps
   maps_subproduct: default
-  possible_maps_subproduct_kwargs: null
   calibrated: false
   catalogs_subproduct: null
   catalog_name: null

--- a/sofind/products/noise_models/so_sat_v1_f1.yaml
+++ b/sofind/products/noise_models/so_sat_v1_f1.yaml
@@ -1,0 +1,290 @@
+system_paths:
+  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/noise_models
+
+allowed_qids_configs:
+- so_basic_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+  lfa:
+    num_splits: 2
+
+  lfb:
+    num_splits: 2
+
+  mfa:
+    num_splits: 2
+
+  mfb:
+    num_splits: 2
+
+  uhfa:
+    num_splits: 2
+
+  uhfb:
+    num_splits: 2
+
+fdw_lf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  #ivar_filt_method: null
+  ivar_fwhms: null
+  #ivar_fwhms: 30
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f030_f040_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f030_f040_mask_obs.fits
+  mask_obs_edgecut: 0
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.7
+  n: 12
+  nback:
+  #- 0
+  - 12
+  nforw:
+  - 0
+  - 6
+  - 6
+  #- 6
+  #- 6
+  - 12
+  - 12 
+  - 12
+  - 12
+  p: 2
+  pback:
+  #- 0
+  - 2
+  pforw:
+  # - 0
+  # - 6
+  # - 4
+  # - 2
+  # - 2
+  # - 12
+  # - 8
+  - 0
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  w_lmax: 405
+  w_lmax_j: 304
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+fdw_mf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+  #  ell_lows:
+  #    - 25
+  #  ell_highs:
+  #    - 50
+  #  profile: cosine    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  #ivar_filt_method: null
+  #ivar_filt_method: scaledep
+  #ivar_fwhms:
+  #  - 15
+  #  - 15
+  #ivar_lmaxs:
+  #  - 25
+  #  - null
+  ivar_fwhms: null
+  #ivar_fwhms: 30
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f090_f150_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f090_f150_mask_obs.fits
+  mask_obs_edgecut: 0
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.3
+  n: 12
+  nback:
+  - 0
+  #- 16
+  nforw:
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12 
+  - 12
+  - 12
+  - 12
+  p: 2
+  pback:
+  - 0
+  #- 2
+  pforw:
+  - 2
+  # - 6
+  # - 4
+  # - 2
+  # - 2
+  # - 12
+  # - 8
+  # - 4
+  # - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+#  w_lmax: 1620
+#  w_lmax_j: 620
+  w_lmax: 2620
+  w_lmax_j: 1600 
+  #w_lmin: 10
+  w_lmin: 15
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+fdw_uhf:
+  noise_model_class: FDW
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  #ivar_filt_method: null
+  ivar_fwhms: null
+  #ivar_fwhms: 30
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f230_f290_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f230_f290_mask_obs.fits
+  mask_obs_edgecut: 0
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  fwhm_fact_pt1:
+  - 1350
+  - 10.0
+  fwhm_fact_pt2:
+  - 5400
+  - 16.0
+  kern_cut: 0.0001
+  lamb: 1.7
+  n: 12
+  nback:
+  #- 0
+  - 6
+  nforw:
+  - 0
+  - 6
+  - 6
+  - 6
+  - 6
+  - 12
+  - 12
+  - 12
+  - 12
+  - 12
+  - 12
+  p: 2
+  pback:
+  #- 0
+  - 2
+  pforw:
+  - 0
+  # - 6
+  # - 4
+  # - 2
+  # - 2
+  # - 12
+  # - 8
+  # - 4
+  # - 2
+  # - 12
+  # - 8
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  - 2
+  w_lmax: 3240
+  w_lmax_j: 2240
+  w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'

--- a/sofind/products/noise_models/so_sat_v1_f1.yaml
+++ b/sofind/products/noise_models/so_sat_v1_f1.yaml
@@ -1,5 +1,6 @@
 system_paths:
-  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/noise_models
+  perlmutter: /global/cfs/cdirs/sobs/v4_sims/mbs/mbs_s0014_20230920
+  rusty: /mnt/home/aduivenvoorden/project/so/20230524_sat_noise/v1/car/mnms
 
 allowed_qids_configs:
 - so_basic_qids.yaml
@@ -41,12 +42,12 @@ fdw_lf:
   - array
   - num_splits
   filter_kwargs:
+    lim: 0.000001
+    lim0: null    
     post_filt_rel_downgrade: 2
   iso_filt_method: harmonic
   ivar_filt_method: basic
-  #ivar_filt_method: null
   ivar_fwhms: null
-  #ivar_fwhms: 30
   ivar_lmaxs: null
   kfilt_lbounds: null
   masks_subproduct: so_sat_v1_f1_masks
@@ -55,6 +56,8 @@ fdw_lf:
   mask_est_apodization: 0
   mask_obs_name: coadd_SAT_f030_f040_mask_obs.fits
   mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
   qid_names_template: '{array}_{freq}'
   srcfree: false
   fwhm_fact_pt1:
@@ -67,30 +70,19 @@ fdw_lf:
   lamb: 1.7
   n: 12
   nback:
-  #- 0
   - 12
   nforw:
   - 0
   - 6
   - 6
-  #- 6
-  #- 6
   - 12
   - 12 
   - 12
   - 12
   p: 2
   pback:
-  #- 0
   - 2
   pforw:
-  # - 0
-  # - 6
-  # - 4
-  # - 2
-  # - 2
-  # - 12
-  # - 8
   - 0
   - 2
   - 2
@@ -121,23 +113,11 @@ fdw_mf:
   - num_splits
   filter_kwargs:
     post_filt_rel_downgrade: 2
-  #  ell_lows:
-  #    - 25
-  #  ell_highs:
-  #    - 50
-  #  profile: cosine    
+    lim: 0.000000001
+    lim0: null    
   iso_filt_method: harmonic
   ivar_filt_method: basic
-  #ivar_filt_method: null
-  #ivar_filt_method: scaledep
-  #ivar_fwhms:
-  #  - 15
-  #  - 15
-  #ivar_lmaxs:
-  #  - 25
-  #  - null
   ivar_fwhms: null
-  #ivar_fwhms: 30
   ivar_lmaxs: null
   kfilt_lbounds: null
   masks_subproduct: so_sat_v1_f1_masks
@@ -146,6 +126,8 @@ fdw_mf:
   mask_est_apodization: 0
   mask_obs_name: coadd_SAT_f090_f150_mask_obs.fits
   mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
   qid_names_template: '{array}_{freq}'
   srcfree: false
   fwhm_fact_pt1:
@@ -155,48 +137,39 @@ fdw_mf:
   - 5400
   - 16.0
   kern_cut: 0.0001
-  lamb: 1.3
-  n: 12
+  lamb: 1.5
+  n: 10
   nback:
   - 0
-  #- 16
   nforw:
+  - 0
+  - 4
   - 6
   - 6
   - 6
-  - 6
-  - 12
-  - 12 
-  - 12
-  - 12
-  - 12
+  - 8 
+  - 10
+  - 10
+  - 10
+  - 10
+  - 10
   p: 2
   pback:
   - 0
-  #- 2
   pforw:
-  - 2
-  # - 6
-  # - 4
-  # - 2
-  # - 2
-  # - 12
-  # - 8
-  # - 4
-  # - 2
+  - 0
   - 2
   - 2
   - 2
   - 2
   - 2
-  - 2
-  - 2
-  - 2
-#  w_lmax: 1620
-#  w_lmax_j: 620
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
   w_lmax: 2620
   w_lmax_j: 1600 
-  #w_lmin: 10
   w_lmin: 15
   model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
   sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
@@ -218,11 +191,11 @@ fdw_uhf:
   - num_splits
   filter_kwargs:
     post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null        
   iso_filt_method: harmonic
   ivar_filt_method: basic
-  #ivar_filt_method: null
   ivar_fwhms: null
-  #ivar_fwhms: 30
   ivar_lmaxs: null
   kfilt_lbounds: null
   masks_subproduct: so_sat_v1_f1_masks
@@ -231,6 +204,8 @@ fdw_uhf:
   mask_est_apodization: 0
   mask_obs_name: coadd_SAT_f230_f290_mask_obs.fits
   mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
   qid_names_template: '{array}_{freq}'
   srcfree: false
   fwhm_fact_pt1:
@@ -243,7 +218,6 @@ fdw_uhf:
   lamb: 1.7
   n: 12
   nback:
-  #- 0
   - 6
   nforw:
   - 0
@@ -259,32 +233,141 @@ fdw_uhf:
   - 12
   p: 2
   pback:
-  #- 0
   - 2
   pforw:
   - 0
-  # - 6
-  # - 4
-  # - 2
-  # - 2
-  # - 12
-  # - 8
-  # - 4
-  # - 2
-  # - 12
-  # - 8
+  - 6
+  - 4
   - 2
   - 2
   - 2
-  - 2
-  - 2
-  - 2
-  - 2
-  - 2
-  - 2
-  - 2
+  - 1
+  - 1
+  - 1
+  - 1
+  - 1
   w_lmax: 3240
   w_lmax_j: 2240
   w_lmin: 10
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_lf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f030_f040_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f030_f040_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_mf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f090_f150_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f090_f150_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_uhf:
+  noise_model_class: Tiled
+  data_model_name: so_sat_v1
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: default
+  possible_maps_subproduct_kwargs: null
+  calibrated: false
+  catalogs_subproduct: null
+  catalog_name: null
+  differenced: false
+  dtype: f4
+  enforce_equal_qid_kwargs:
+  - array
+  - num_splits
+  filter_kwargs:
+    post_filt_rel_downgrade: 2
+    lim: 0.000000001
+    lim0: null    
+  iso_filt_method: harmonic
+  ivar_filt_method: basic
+  ivar_fwhms: null
+  ivar_lmaxs: null
+  kfilt_lbounds: null
+  masks_subproduct: so_sat_v1_f1_masks
+  mask_est_name: coadd_SAT_f230_f290_mask_est.fits
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_name: coadd_SAT_f230_f290_mask_obs.fits
+  mask_obs_edgecut: 0
+  model_lim: 0.000001
+  model_lim0: null  
+  qid_names_template: '{array}_{freq}'
+  srcfree: false
+  delta_ell_smooth: 70
+  height_deg: 12.0
+  width_deg: 12.0  
   model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
   sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'

--- a/sofind/systems.py
+++ b/sofind/systems.py
@@ -1,5 +1,6 @@
 ### ADD SYSTEMS ON WHICH SOFIND PRODUCTS ARE SERVED HERE ###
 sofind_systems = [
     'della',
-    'perlmutter'
+    'perlmutter',
+    'rusty'
 ]


### PR DESCRIPTION
This PR adds the configs needed for the `so_sat_mbs_v1` map-based noise models