### PR TITLE
act_nilc_noise_070123

### DIFF
--- a/sofind/datamodels/act_dr6v4_nilc070123.yaml
+++ b/sofind/datamodels/act_dr6v4_nilc070123.yaml
@@ -1,0 +1,11 @@
+qids_config: act_dr6v4_nilc070123_qids.yaml  
+
+maps:
+  wavelet: act_dr6v4_nilc070123_wav
+  tiled: act_dr6v4_nilc070123_tiled
+
+masks:
+  default: act_dr6v4_nilc070123_masks.yaml
+
+noise_models:
+  default_config: act_dr6v4_nilc070123.yaml

--- a/sofind/products/maps/README.md
+++ b/sofind/products/maps/README.md
@@ -9,6 +9,8 @@ We give additional information for each `maps` config file, such as permissible 
 | act_dr6v3_pwv_split.yaml | `pa4a`, `pa4a_dw`, `pa4a_dd`, `pa4b`, `pa4b_dw`, `pa4b_dd`, `pa5a`, `pa5a_dw`, `pa5a_dd`, `pa5b`, `pa5b_dw`, `pa5b_dd`, `pa6a`, `pa6a_dw`, `pa6a_dd`, `pa6b`, `pa6b_dw`, `pa6b_dd` |
 | so_scan_s0003.yaml | `lfa`, `lfb`, `mfa`, `mfb`, `uhfa`, `uhfb` |
 | so_sat_v1_f1.yaml | `lfa`, `lfb`, `mfa`, `mfb`, `uhfa`, `uhfb` |
+| act_dr6v4_nilc070123_wav | `ilc_y`, `ilc_y_noKspaceCor`, `ilc_y_planck` |
+| act_dr6v4_nilc070123_tiled | `ilc_y`, `ilc_y_noKspaceCor`, `ilc_y_planck` |
 
 ## Required Additional Keyword Arguments
 | Config File | Additional Keywords | Possible Values |
@@ -18,3 +20,5 @@ We give additional information for each `maps` config file, such as permissible 
 | act_dr6v3_pwv_split.yaml | `null_split` | `low_pwv`, `high_pwv` |
 | so_scan_s0003.yaml | |
 | so_sat_v1_f1.yaml | |
+| act_dr6v4_nilc070123_wav | |
+| act_dr6v4_nilc070123_tiled | |

--- a/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
@@ -1,6 +1,6 @@
 system_paths:
   perlmutter: ADDME
-  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/tiled
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/ivar_tiled
 
 allowed_qids_configs:
 - act_dr6v4_nilc070123_qids.yaml

--- a/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
@@ -1,0 +1,12 @@
+system_paths:
+  perlmutter: ADDME
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/tiled
+
+allowed_qids_configs:
+- act_dr6v4_nilc070123_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+
+split_map_file_template: 'ilc_yy_{nilc_type}_{maptag}.fits'

--- a/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_tiled.yaml
@@ -1,5 +1,5 @@
 system_paths:
-  perlmutter: ADDME
+  perlmutter: /global/cfs/cdirs/act/www/dr6_nilc/mnms_20230220/ivar_tiled
   rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/ivar_tiled
 
 allowed_qids_configs:

--- a/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
@@ -1,5 +1,5 @@
 system_paths:
-  perlmutter: ADDME
+  perlmutter: /global/cfs/cdirs/act/www/dr6_nilc/mnms_20230220/ivar_wavelet
   rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/ivar_wavelet
 
 allowed_qids_configs:

--- a/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
@@ -1,6 +1,6 @@
 system_paths:
   perlmutter: ADDME
-  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/wavelet
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/ivar_wavelet
 
 allowed_qids_configs:
 - act_dr6v4_nilc070123_qids.yaml

--- a/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
+++ b/sofind/products/maps/act_dr6v4_nilc070123_wav.yaml
@@ -1,0 +1,12 @@
+system_paths:
+  perlmutter: ADDME
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/wavelet
+
+allowed_qids_configs:
+- act_dr6v4_nilc070123_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+
+split_map_file_template: 'ilc_yy_{nilc_type}_{maptag}.fits'

--- a/sofind/products/masks/act_dr6v4_nilc070123_masks.yaml
+++ b/sofind/products/masks/act_dr6v4_nilc070123_masks.yaml
@@ -1,0 +1,8 @@
+system_paths:
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/masks
+
+allowed_qids_configs: 'all'
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:

--- a/sofind/products/masks/act_dr6v4_nilc070123_masks.yaml
+++ b/sofind/products/masks/act_dr6v4_nilc070123_masks.yaml
@@ -1,4 +1,5 @@
 system_paths:
+  perlmutter: /global/cfs/cdirs/act/www/dr6_nilc/mnms_20230220/masks
   rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms/masks
 
 allowed_qids_configs: 'all'

--- a/sofind/products/noise_models/act_dr6v4_nilc070123.yaml
+++ b/sofind/products/noise_models/act_dr6v4_nilc070123.yaml
@@ -1,0 +1,174 @@
+system_paths:
+  perlmutter: 
+  rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms
+
+allowed_qids_configs:
+- act_dr6v4_nilc070123_qids.yaml
+
+allowed_qids: 'all'
+
+allowed_qids_extra_kwargs:
+
+tile:
+  noise_model_class: Tiled
+  data_model_name: act_dr6v4_nilc070123
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: tiled    
+  filter_kwargs:
+    post_filt_rel_downgrade: 1
+    lim: 0.000000001
+    lim0: null
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_edgecut: 0
+  masks_subproduct: default
+  mask_est_name: null
+  differenced: null
+  mask_obs_name: wide_mask_GAL070_apod_1.50_deg_wExtended_mask_obs_dg2.fits
+  ivar_filt_method: basic
+  dtype: f4
+  qid_names_template: null
+  ivar_lmaxs: 0
+  srcfree: null
+  catalog_name: null
+  catalogs_subproduct: null
+  iso_filt_method: harmonic  
+  kfilt_lbounds: null
+  enforce_equal_qid_kwargs:
+   - num_splits
+  ivar_fwhms: null
+  calibrated: False
+  model_lim0: null
+  model_lim: null  
+  delta_ell_smooth: 400
+  height_deg: 4.0
+  width_deg: 4.0
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+tile_planck:
+  noise_model_class: Tiled
+  data_model_name: act_dr6v4_nilc070123
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: tiled    
+  filter_kwargs:
+    post_filt_rel_downgrade: 1
+    lim: 0.000000001
+    lim0: null
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_edgecut: 0
+  masks_subproduct: default
+  mask_est_name: null
+  differenced: null
+  mask_obs_name: wide_mask_GAL070_apod_1.50_deg_wExtended_mask_obs_dg4.fits
+  ivar_filt_method: basic
+  dtype: f4
+  qid_names_template: null
+  ivar_lmaxs: 0
+  srcfree: null
+  catalog_name: null
+  catalogs_subproduct: null
+  iso_filt_method: harmonic  
+  kfilt_lbounds: null
+  enforce_equal_qid_kwargs:
+   - num_splits
+  ivar_fwhms: null
+  calibrated: False
+  model_lim0: null
+  model_lim: null  
+  delta_ell_smooth: 400
+  height_deg: 4.0
+  width_deg: 4.0
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+wav:
+  noise_model_class: Wavelet
+  data_model_name: act_dr6v4_nilc070123
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: wavelet  
+  filter_kwargs:
+    post_filt_rel_downgrade: 1
+    lim: 0.000000001
+    lim0: null    
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_edgecut: 0
+  masks_subproduct: default
+  mask_est_name: null
+  differenced: null
+  mask_obs_name: wide_mask_GAL070_apod_1.50_deg_wExtended_mask_obs_dg2.fits
+  ivar_filt_method: null
+  dtype: f4
+  qid_names_template: null
+  ivar_lmaxs: 0
+  srcfree: null
+  catalog_name: null
+  catalogs_subproduct: null
+  iso_filt_method: harmonic  
+  kfilt_lbounds: null
+  enforce_equal_qid_kwargs:
+   - num_splits
+  ivar_fwhms: null
+  calibrated: False
+  model_lim0: null
+  model_lim: null  
+  fwhm_fact_pt1:
+  - 1350
+  - 2.
+  fwhm_fact_pt2:
+  - 5400
+  - 2.  
+  lamb: 1.3
+  w_lmax_j: 6000
+  w_lmin: 300
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'
+
+wav_planck:
+  noise_model_class: Wavelet
+  data_model_name: act_dr6v4_nilc070123
+  subproduct: default
+  maps_product: maps
+  maps_subproduct: wavelet  
+  filter_kwargs:
+    post_filt_rel_downgrade: 1
+    lim: 0.000000001
+    lim0: null
+  mask_est_edgecut: 0
+  mask_est_apodization: 0
+  mask_obs_edgecut: 0
+  masks_subproduct: default
+  mask_est_name: null
+  differenced: null
+  mask_obs_name: wide_mask_GAL070_apod_1.50_deg_wExtended_mask_obs_dg4.fits
+  ivar_filt_method: null
+  dtype: f4
+  qid_names_template: null
+  ivar_lmaxs: 0
+  srcfree: null
+  catalog_name: null
+  catalogs_subproduct: null
+  iso_filt_method: harmonic  
+  kfilt_lbounds: null
+  enforce_equal_qid_kwargs:
+   - num_splits
+  ivar_fwhms: null
+  calibrated: False
+  model_lim0: null
+  model_lim: null  
+  fwhm_fact_pt1:
+  - 1350
+  - 2.
+  fwhm_fact_pt2:
+  - 5400
+  - 2.
+  lamb: 1.3
+  w_lmax_j: 3100
+  w_lmin: 300
+  model_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_model'
+  sim_file_template: '{config_name}_{noise_model_name}_{qid_names}_lmax{lmax}_{num_splits}way_set{split_num}_noise_sim_{alm_str}{sim_num:04}'

--- a/sofind/products/noise_models/act_dr6v4_nilc070123.yaml
+++ b/sofind/products/noise_models/act_dr6v4_nilc070123.yaml
@@ -1,5 +1,5 @@
 system_paths:
-  perlmutter: 
+  perlmutter: /global/cfs/cdirs/act/www/dr6_nilc/mnms_20230220/models
   rusty: /mnt/home/aduivenvoorden/project/actpol/20230622_nilc_july/icov/mnms
 
 allowed_qids_configs:

--- a/sofind/qids/act_dr6v4_nilc070123_qids.yaml
+++ b/sofind/qids/act_dr6v4_nilc070123_qids.yaml
@@ -1,0 +1,11 @@
+ilc_y:
+  nilc_type: wBP
+  num_splits: 1
+
+ilc_y_noKspaceCor:
+  nilc_type: wBP_noKspaceCor
+  num_splits: 1
+
+ilc_y_planck:
+  nilc_type: wBP_planck
+  num_splits: 1


### PR DESCRIPTION
Added `act_dr6v4_nilc070123` dataset and products to sofind that can be used to draw mnms noise simulations of the NILC Compton y maps.

Some notes

- Each of 6 mnms models has been estimated from 10 input sims containing identically distributed noise. This is not a mode that mnms currently supports, so the model generation has been handled by a bespoke script. As a result, the noise models configs included here can only be used to draw simulations, they cannot be used to generate new models. No input maps are included in the release for this reason as well. 
- The input simulations from which the mnms models were generated came in two forms: wavelet-based sims and tiled-based sims. As a result, there are two separate map products (`act_dr6v4_nilc070123_tiled.yaml` and `act_dr6v4_nilc070123_wav.yaml`) The `tile` and `wav` models included in `act_dr6v4_nilc070123.yaml` correspond to the  tile and wavelet input maps, respectively.