### PR TITLE
Defer mnms load

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Currently:
 All other dependencies (e.g. `numpy` etc.) are required by packages listed here, especially by `pixell`.
 
 ## Installation
-Clone this repo and the `mnms` repo. `mnms` and `sofind` are install-time circular dependencies. Thus, they need to be installed in the same call to pip:
+Clone this repo and install it via pip:
 ```shell
-$ pip install path/to/mnms path/to/sofind
+$ pip install path/to/sofind
 ```
 or 
 ```shell
-$ pip install -e path/to/mnms -e path/to/sofind
+$ pip install -e path/to/sofind
 ```
 to see changes to source code automatically updated in your environment.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ setup(
     packages=['sofind'],
     version='0.0.7',
     install_requires=[
-        'pixell>=0.12.0',
-        'mnms>=0.0.6'
+        'pixell>=0.12.0'
     ]
     )

--- a/sofind/products/noise_models/__init__.py
+++ b/sofind/products/noise_models/__init__.py
@@ -5,7 +5,7 @@ import os
 def _defer_mnms_load():
         """
         The purpose of this function is to defer the load of `mnms.io` module when loading 
-        the `NoiseModel` (and not at installation time to avoid cyclic-dependency)
+        the `NoiseModel` (and not at installation time to avoid circular dependency)
         """
         try:
             global io

--- a/sofind/products/noise_models/__init__.py
+++ b/sofind/products/noise_models/__init__.py
@@ -1,8 +1,17 @@
 from ..products import Product, get_implements_decorator
 
-from mnms import io
-
 import os
+
+def _defer_mnms_load():
+        """
+        The purpose of this function is to defer the load of `mnms.io` module at load 
+        time (and not at installation time to avoid cyclic-dependency)
+        """
+        try:
+            global io
+            from mnms import io
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("You need to install `mnms` to use `sofind.NoiseModel`.")
 
 
 class NoiseModel(Product):
@@ -55,6 +64,7 @@ class NoiseModel(Product):
         ValueError
             If 'which' is not 'models' or 'sims'.
         """
+        _defer_mnms_load()        
         subprod_dict = self.get_subproduct_dict(__name__, subproduct)
         param_dict = subprod_dict[noise_model_name]
 
@@ -161,6 +171,7 @@ class NoiseModel(Product):
         ValueError
             If 'which' is not 'models' or 'sims'.
         """
+        _defer_mnms_load()        
         subprod_dict = self.get_subproduct_dict(__name__, subproduct)
         param_dict = subprod_dict[noise_model_name]
 

--- a/sofind/products/noise_models/__init__.py
+++ b/sofind/products/noise_models/__init__.py
@@ -4,8 +4,8 @@ import os
 
 def _defer_mnms_load():
         """
-        The purpose of this function is to defer the load of `mnms.io` module at load 
-        time (and not at installation time to avoid cyclic-dependency)
+        The purpose of this function is to defer the load of `mnms.io` module when loading 
+        the `NoiseModel` (and not at installation time to avoid cyclic-dependency)
         """
         try:
             global io


### PR DESCRIPTION
The PR proposes to defer the load of `mnms` module from `sofind.NoiseModel` to avoid circular dependency between `sofind` and `mnms` at installation time. Consequently, `sofind` can now be installed independently of `mnms`: when loading the `sofind.NoiseModel`, in case `mnms` is not installed, an exception is raised with an explicit message telling the user to install `mnms`.