### PR TITLE
Defer mnms load

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ For any questions please reach out to Zach Atkins (email: [zatkins@princeton.edu
 
 ## Dependencies
 Currently:
-* from `simonsobs`: [`pixell`](https://github.com/simonsobs/pixell), [`mnms`](https://github.com/simonsobs/mnms)
+* from `simonsobs`: [`pixell`](https://github.com/simonsobs/pixell)
+    * [`mnms`](https://github.com/simonsobs/mnms) is required if you are using `sofind` for any functionality related to `mnms` products.
 
-All other dependencies (e.g. `numpy` etc.) are required by packages listed here, especially by `pixell`. The `mnms` dependency currently only appears when calling `DataModel.get_noise_fn` or `DataModel.read_noise`. So, one can install `sofind` without `mnms`, but these functions will not work. 
+All other dependencies (e.g. `numpy` etc.) are required by packages listed here, especially by `pixell`.
 
 ## Installation
 Clone this repo and install it via pip:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ For any questions please reach out to Zach Atkins (email: [zatkins@princeton.edu
 Currently:
 * from `simonsobs`: [`pixell`](https://github.com/simonsobs/pixell), [`mnms`](https://github.com/simonsobs/mnms)
 
-All other dependencies (e.g. `numpy` etc.) are required by packages listed here, especially by `pixell`.
+All other dependencies (e.g. `numpy` etc.) are required by packages listed here, especially by `pixell`. The `mnms` dependency currently only appears when calling `DataModel.get_noise_fn` or `DataModel.read_noise`. So, one can install `sofind` without `mnms`, but these functions will not work. 
 
 ## Installation
-Clone this repo and the `mnms` repo. `mnms` and `sofind` are install-time circular dependencies. Thus, they need to be installed in the same call to pip:
+Clone this repo and install it via pip:
 ```shell
-$ pip install path/to/mnms path/to/sofind
+$ pip install path/to/sofind
 ```
 or 
 ```shell
-$ pip install -e path/to/mnms -e path/to/sofind
+$ pip install -e path/to/sofind
 ```
 to see changes to source code automatically updated in your environment.
 

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,6 @@ setup(
     packages=['sofind'],
     version='0.0.8',
     install_requires=[
-        'pixell>=0.12.0'    ]
+        'pixell>=0.12.0'
+        ]
     )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@ from setuptools import setup
 setup(
     name='sofind',
     packages=['sofind'],
-    version='0.0.7',
+    version='0.0.8',
     install_requires=[
-        'pixell>=0.12.0',
-        'mnms>=0.0.6'
-    ]
+        'pixell>=0.12.0'    ]
     )


### PR DESCRIPTION
Avoids circular install-time dependency with `mnms`. Implements https://github.com/simonsobs/sofind/pull/10