### PR TITLE
sofind paths for Penn's GPC2

### DIFF
--- a/sofind/products/beams/beams_nemo.yaml
+++ b/sofind/products/beams/beams_nemo.yaml
@@ -2,6 +2,7 @@ system_paths:
   della: 
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/beams/planck_beams/
   niagara: /scratch/r/rbond/jaejoonk/lensing_pipeline_data/planck_beams/
+  penn-gpc: /data5/act/beams/planck_beams/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/beams/beams_v4_20230902.yaml
+++ b/sofind/products/beams/beams_v4_20230902.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/adriaand/beams/20230902_beams/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/v4_maps/20230902_beams/
   niagara: /project/r/rbond/jaejoonk/lensing_pipeline_data/beams_path/20230902/
+  penn-gpc: /data5/act/beams/20230902_beams/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/beams/beams_v4_day_20240115.yaml
+++ b/sofind/products/beams/beams_v4_day_20240115.yaml
@@ -1,6 +1,7 @@
 system_paths:
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/daybeam_srcs/20240115/release/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/v4_maps/20240115_day_beams/
+  penn-gpc: /data5/act/DR6_products/v4_maps/daytime/20240115_day_beams/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/calibrationspkl/dr6v4_cal_230523.yaml
+++ b/sofind/products/calibrationspkl/dr6v4_cal_230523.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/alaposta/calibrations/dr6_v4_230523/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/calibration/dr6_v4_230523/
   niagara: /project/r/rbond/jaejoonk/lensing_pipeline_data/calibration/dr6_v4_230523/
+  penn-gpc: /data5/act/DR6_products/calibration/dr6_v4_230523/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/calibrationspkl/dr6v4_cal_240410.yaml
+++ b/sofind/products/calibrationspkl/dr6v4_cal_240410.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter:
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/calibration/dr6_v4_240410/
   niagara: /project/r/rbond/jaejoonk/lensing_pipeline_data/calibration/dr6_v4_240410/
+  penn-gpc: /data5/act/DR6_products/calibration/dr6_v4_240410/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/calibrationspkl/dr6v4_poleff_231113.yaml
+++ b/sofind/products/calibrationspkl/dr6v4_poleff_231113.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter: 
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/calibration/dr6_v4_231113/
   niagara: /project/r/rbond/jaejoonk/lensing_pipeline_data/calibration/dr6_v4_231113/
+  penn-gpc: /data5/act/DR6_products/calibration/dr6_v4_231113/
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/catalogs/inpaint_catalogs.yaml
+++ b/sofind/products/catalogs/inpaint_catalogs.yaml
@@ -3,7 +3,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/catalogs/inpaint_catalogs_20220316
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/catalogues/inpaint_catalogs
   niagara: /home/r/rbond/jiaqu/projects/catalogs/inpaint_catalogs_20241002
-  gpc2: /data5/act/catalogs/inpaint_catalogs_20241002
+  penn-gpc: /data5/act/catalogs/inpaint_catalogs_20241002
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/catalogs/inpaint_catalogs.yaml
+++ b/sofind/products/catalogs/inpaint_catalogs.yaml
@@ -3,6 +3,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/catalogs/inpaint_catalogs_20220316
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/catalogues/inpaint_catalogs
   niagara: /home/r/rbond/jiaqu/projects/catalogs/inpaint_catalogs_20241002
+  gpc2: /data5/act/catalogs/inpaint_catalogs_20241002
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/maps/act_dr6v4.yaml
+++ b/sofind/products/maps/act_dr6v4.yaml
@@ -3,6 +3,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/v4_maps/release_20230316/
+  gpc2: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4.yaml
+++ b/sofind/products/maps/act_dr6v4.yaml
@@ -3,7 +3,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/v4_maps/release_20230316/
-  gpc2: /data5/act/maps/dr6v4_20230316
+  penn-gpc: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_el_split.yaml
+++ b/sofind/products/maps/act_dr6v4_el_split.yaml
@@ -2,7 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
-  gpc2: /data5/act/maps/dr6v4_20230316
+  penn-gpc: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_el_split.yaml
+++ b/sofind/products/maps/act_dr6v4_el_split.yaml
@@ -2,6 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
+  gpc2: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_inout_split.yaml
+++ b/sofind/products/maps/act_dr6v4_inout_split.yaml
@@ -2,7 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
-  gpc2: /data5/act/maps/dr6v4_20230316
+  penn-gpc: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_inout_split.yaml
+++ b/sofind/products/maps/act_dr6v4_inout_split.yaml
@@ -2,6 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
+  gpc2: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_pwv_split.yaml
+++ b/sofind/products/maps/act_dr6v4_pwv_split.yaml
@@ -2,7 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
-  gpc2: /data5/act/maps/dr6v4_20230316
+  penn-gpc: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_pwv_split.yaml
+++ b/sofind/products/maps/act_dr6v4_pwv_split.yaml
@@ -2,6 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
+  gpc2: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_t_split.yaml
+++ b/sofind/products/maps/act_dr6v4_t_split.yaml
@@ -2,7 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
-  gpc2: /data5/act/maps/dr6v4_20230316
+  penn-gpc: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_dr6v4_t_split.yaml
+++ b/sofind/products/maps/act_dr6v4_t_split.yaml
@@ -2,6 +2,7 @@ system_paths:
   della: /scratch/gpfs/ACT/dr6v4/maps/dr6v4_20230316/release
   perlmutter: /global/cfs/cdirs/act/data/sigurdkn/actpol/maps/dr6v4_20230316/release
   niagara: /gpfs/fs0/project/r/rbond/sigurdkn/actpol/maps/dr6v4_20230316/release
+  gpc2: /data5/act/maps/dr6v4_20230316
 
 allowed_qids_configs:
 - act_dr6vX_qids.yaml

--- a/sofind/products/maps/act_nemov3.yaml
+++ b/sofind/products/maps/act_nemov3.yaml
@@ -1,6 +1,7 @@
 system_paths:
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/models/
   niagara: /scratch/r/rbond/jaejoonk/lensing_pipeline_data/models/
+  gpc2: /data5/act/DR6_products/models/
 
 allowed_qids_configs:
   - act_nemo.yaml

--- a/sofind/products/maps/act_nemov3.yaml
+++ b/sofind/products/maps/act_nemov3.yaml
@@ -1,7 +1,7 @@
 system_paths:
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/models/
   niagara: /scratch/r/rbond/jaejoonk/lensing_pipeline_data/models/
-  gpc2: /data5/act/DR6_products/models/
+  penn-gpc: /data5/act/DR6_products/models/
 
 allowed_qids_configs:
   - act_nemo.yaml

--- a/sofind/products/masks/lensing_masks.yaml
+++ b/sofind/products/masks/lensing_masks.yaml
@@ -2,7 +2,7 @@ system_paths:
   perlmutter: 
   niagara: 
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/masks/
-  gpc2: /data5/act/DR6_products/masks/
+  penn-gpc: /data5/act/DR6_products/masks/
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/masks/lensing_masks.yaml
+++ b/sofind/products/masks/lensing_masks.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter: 
   niagara: 
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/masks/
+  gpc2: /data5/act/DR6_products/masks/
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/masks/lensing_masks_20240919b.yaml
+++ b/sofind/products/masks/lensing_masks_20240919b.yaml
@@ -1,7 +1,8 @@
 system_paths:
   perlmutter: 
-  niagara: /gpfs/fs0/project/r/rbond/msyriac/masks/dr6v4_lensing_20240919b_masks/baseline
+  niagara: /gpfs/fs0/project/r/rbond/msyriac/masks/dr6v4_lensing_20240919b_masks/baseline/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/masks/
+  gpc2: /data5/act/masks/dr6v4_lensing_20240919b_masks/baseline/
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/masks/lensing_masks_20240919b.yaml
+++ b/sofind/products/masks/lensing_masks_20240919b.yaml
@@ -2,7 +2,7 @@ system_paths:
   perlmutter: 
   niagara: /gpfs/fs0/project/r/rbond/msyriac/masks/dr6v4_lensing_20240919b_masks/baseline/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/masks/
-  gpc2: /data5/act/masks/dr6v4_lensing_20240919b_masks/baseline/
+  penn-gpc: /data5/act/masks/dr6v4_lensing_20240919b_masks/baseline/
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/masks/mnms_masks.yaml
+++ b/sofind/products/masks/mnms_masks.yaml
@@ -3,6 +3,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/zatkins/data/simonsobs/mnms/masks
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/simulations/mnms/masks/
   niagara: /scratch/r/rbond/jaejoonk/mnms/masks/
+  penn-gpc: /data5/act/mnms/masks/
 
 allowed_qids_configs: 'all'
 

--- a/sofind/products/transfer_func/tf_dr6v4_240416.yaml
+++ b/sofind/products/transfer_func/tf_dr6v4_240416.yaml
@@ -2,7 +2,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/alaposta/transfer_functions/dr6_v4_legacy_240416/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/transfer_functions/dr6_v4_legacy_240416/
   niagara: /scratch/r/rbond/jaejoonk/lensing_pipeline_data/transfer_functions/dr6_v4_legacy_240416/
-  gpc2: /data5/act/DR6_products/transfer_functions/dr6_v4_legacy_240416/
+  penn-gpc: /data5/act/DR6_products/transfer_functions/dr6_v4_legacy_240416/
 
 
 allowed_qids_configs:

--- a/sofind/products/transfer_func/tf_dr6v4_240416.yaml
+++ b/sofind/products/transfer_func/tf_dr6v4_240416.yaml
@@ -2,6 +2,7 @@ system_paths:
   perlmutter: /global/cfs/cdirs/act/data/alaposta/transfer_functions/dr6_v4_legacy_240416/
   dirac: /rds/project/dirac_vol5/rds-dirac-dp002/AdvACT/DR6_products/transfer_functions/dr6_v4_legacy_240416/
   niagara: /scratch/r/rbond/jaejoonk/lensing_pipeline_data/transfer_functions/dr6_v4_legacy_240416/
+  gpc2: /data5/act/DR6_products/transfer_functions/dr6_v4_legacy_240416/
 
 
 allowed_qids_configs:

--- a/sofind/systems.py
+++ b/sofind/systems.py
@@ -5,5 +5,5 @@ sofind_systems = [
     'rusty',
     'dirac',
     'niagara',
-    'gpc2'
+    'penn-gpc'
 ]

--- a/sofind/systems.py
+++ b/sofind/systems.py
@@ -4,5 +4,6 @@ sofind_systems = [
     'perlmutter',
     'rusty',
     'dirac',
-    'niagara'
+    'niagara',
+    'gpc2'
 ]


### PR DESCRIPTION
Might've been removed at some point? But may still be useful to have when e.g. running dr6+ preprocessing tests on GPC2